### PR TITLE
Update to use yaml-rust2 instead of yaml-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ repository = "https://github.com/qtfkwk/merge-yaml-hash"
 license = "MIT"
 
 [dependencies]
-yaml-rust = "0.4.3"
-linked-hash-map = "0.5.2"
+hashlink = "0.8"
+yaml-rust2 = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ assert_eq!(
 hash.merge("tests/c.yaml"); // "banana: 3"
 assert_eq!(
     hash.to_string(),
-    "apple: 1\nbanana: 3\ncherry:\n  sweet: 1\n  tart: 2",
+    "apple: 1\ncherry:\n  sweet: 1\n  tart: 2\nbanana: 3",
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 YAML Hash with merge/update capabilities
 
-Wrapper around `yaml_rust::yaml::Hash`, which is a type alias for
+Wrapper around `yaml_rust2::yaml::Hash`, which is a type alias for
 `linked_hash_map::LinkedHashMap`
 
 # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../README.md")]
 
-use linked_hash_map::Entry;
-use yaml_rust::yaml::Hash;
-pub use yaml_rust::Yaml;
-use yaml_rust::{YamlEmitter, YamlLoader};
+use hashlink::linked_hash_map::Entry;
+use yaml_rust2::yaml::Hash;
+pub use yaml_rust2::Yaml;
+use yaml_rust2::{YamlEmitter, YamlLoader};
 
 #[cfg(test)]
 mod tests;
@@ -12,7 +12,7 @@ mod tests;
 
 YAML Hash with merge/update capabilities
 
-Wrapper around `yaml_rust::yaml::Hash`, which is a type alias for `linked_hash_map::LinkedHashMap`
+Wrapper around `yaml_rust2::yaml::Hash`, which is a type alias for `linked_hash_map::LinkedHashMap`
 
 */
 #[derive(Debug, Default)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -64,7 +64,7 @@ fn merge_multiple_string_string_with_conflict_2() {
     let mut hash = MergeYamlHash::new();
     let yaml1 = "apple: 1\nbanana: 2".to_string();
     let yaml2 = "apple: 3".to_string();
-    let result = "apple: 3\nbanana: 2";
+    let result = "banana: 2\napple: 3";
     hash.merge_vec(vec![yaml1, yaml2]);
     assert_eq!(hash.to_string(), result);
 }
@@ -74,7 +74,7 @@ fn merge_multiple_string_string_with_conflict_3() {
     let mut hash = MergeYamlHash::new();
     let yaml1 = "apple: 1\nbanana: 2\ncherry: 3".to_string();
     let yaml2 = "banana: 4".to_string();
-    let result = "apple: 1\nbanana: 4\ncherry: 3";
+    let result = "apple: 1\ncherry: 3\nbanana: 4";
     hash.merge_vec(vec![yaml1, yaml2]);
     assert_eq!(hash.to_string(), result);
 }

--- a/t/README.md
+++ b/t/README.md
@@ -2,7 +2,7 @@
 
 YAML Hash with merge/update capabilities
 
-Wrapper around `yaml_rust::yaml::Hash`, which is a type alias for
+Wrapper around `yaml_rust2::yaml::Hash`, which is a type alias for
 `linked_hash_map::LinkedHashMap`
 
 # Example


### PR DESCRIPTION
Updated dependencies to use `yaml-rust2` instead of `yaml-rust` and necessary changes to tests and dependencies where needed